### PR TITLE
Implement Raspberry Pi network binding fix: configure services to lis…

### DIFF
--- a/RASPBERRY_PI_NETWORK_FIX.md
+++ b/RASPBERRY_PI_NETWORK_FIX.md
@@ -1,0 +1,80 @@
+# Raspberry Pi Network Binding Fix
+
+## Problem
+Applikationen lyssnade endast på `127.0.0.1` (localhost) istället för `0.0.0.0` (alla nätverksinterfaces), vilket gjorde den otillgänglig från andra enheter på nätverket.
+
+## Root Cause
+.NET Aspire och Kestrel binder som standard till localhost av säkerhetsskäl. Detta är korrekt för utvecklingsmiljöer men fungerar inte för Raspberry Pi-deployment där vi vill att applikationen ska vara nåbar från nätverket.
+
+## Solution
+Implementerade en Raspberry Pi-specifik konfiguration som tvingar alla komponenter att binda till `0.0.0.0`:
+
+### 1. AppHost.cs (Kod-nivå)
+```csharp
+var isRaspberryPi = Environment.GetEnvironmentVariable("DANCECOURSE_RASPBERRY_PI") == "true";
+
+if (isRaspberryPi)
+{
+    // Force API to bind to all interfaces on Raspberry Pi
+    api.WithEnvironment("ASPNETCORE_URLS", "http://0.0.0.0:7177");
+    
+    // Force Web to bind to all interfaces on Raspberry Pi
+    web.WithEnvironment("ASPNETCORE_URLS", "http://0.0.0.0:5001");
+}
+```
+
+### 2. Miljövariabler (raspberry-pi-start.sh)
+```bash
+export DANCECOURSE_RASPBERRY_PI=true
+export DOTNET_DASHBOARD_URLS="http://0.0.0.0:15000"
+export DOTNET_URLS="http://0.0.0.0:15000"
+export ASPNETCORE_HTTP_PORTS=""  # Töm denna så ASPNETCORE_URLS används
+```
+
+### 3. SystemD Service
+```ini
+Environment=DANCECOURSE_RASPBERRY_PI=true
+Environment=DOTNET_DASHBOARD_URLS=http://0.0.0.0:15000
+Environment=DOTNET_URLS=http://0.0.0.0:15000
+Environment=ASPNETCORE_HTTP_PORTS=
+```
+
+## Verification
+Efter fix ska `ss -lntp` visa:
+```
+0.0.0.0:15000  (Aspire Dashboard)
+0.0.0.0:5001   (Web App)
+0.0.0.0:7177   (API)
+```
+
+Istället för tidigare:
+```
+127.0.0.1:15000  ❌ Endast localhost
+127.0.0.1:5001   ❌ Endast localhost
+127.0.0.1:7177   ❌ Endast localhost
+```
+
+## Testing
+```bash
+# På Raspberry Pi
+./raspberry-pi-debug.sh
+
+# Förväntat resultat:
+# ✓ Port 15000 lyssnar på ALLA nätverksinterfaces (0.0.0.0:15000)
+# ✓ Port 5001 lyssnar på ALLA nätverksinterfaces (0.0.0.0:5001)
+# ✓ Port 7177 lyssnar på ALLA nätverksinterfaces (0.0.0.0:7177)
+```
+
+## Files Modified
+1. `src/DanceCourseCreator.AppHost/AppHost.cs` - Raspberry Pi-specifik binding
+2. `raspberry-pi-start.sh` - Miljövariabel-konfiguration
+3. `raspberry-pi-install.sh` - SystemD service template
+4. `raspberry-pi-update.sh` - SystemD service update
+
+## Security Note
+Att binda till `0.0.0.0` exponerar tjänsterna för hela nätverket. Detta är avsiktligt för Raspberry Pi-deployment men ska endast användas i privata nätverk. För produktion på internet, använd Nginx reverse proxy med SSL och brandväggskonfiguration.
+
+## Related Issues
+- Port conflict med Privatekonomi (löst med olika portar: 15000, 5001, 7177)
+- API-katalognamn (DanceCourseCreator.API med stort API)
+- appsettings.Production.json måste finnas för att Urls-konfiguration ska användas

--- a/raspberry-pi-install.sh
+++ b/raspberry-pi-install.sh
@@ -1066,6 +1066,8 @@ WorkingDirectory=$working_dir
 Environment=ASPNETCORE_ENVIRONMENT=Production
 Environment=DANCECOURSE_RASPBERRY_PI=true
 Environment=DOTNET_DASHBOARD_URLS=http://0.0.0.0:$DEFAULT_PORT
+Environment=DOTNET_URLS=http://0.0.0.0:$DEFAULT_PORT
+Environment=ASPNETCORE_HTTP_PORTS=
 Environment=DOTNET_ROOT=$HOME/.dotnet
 ExecStart=$exec_command
 Restart=always

--- a/raspberry-pi-start.sh
+++ b/raspberry-pi-start.sh
@@ -95,8 +95,11 @@ export DANCECOURSE_RASPBERRY_PI=true
 export ASPNETCORE_ENVIRONMENT=Production
 
 # Konfigurera Aspire Dashboard för att lyssna på alla nätverksinterfaces
-# OBS: Sätt inte ASPNETCORE_URLS här eftersom det ärvs av Web/API och skriver över deras portar
 export DOTNET_DASHBOARD_URLS="http://0.0.0.0:15000"
+
+# Konfigurera Kestrel för att explicit lyssna på alla interfaces
+export ASPNETCORE_HTTP_PORTS=""  # Töm denna så att ASPNETCORE_URLS används istället
+export DOTNET_URLS="http://0.0.0.0:15000"
 
 # Check if using published binaries or source
 INSTALL_DIR="$HOME/DanceCourseCreator"

--- a/raspberry-pi-update.sh
+++ b/raspberry-pi-update.sh
@@ -361,6 +361,8 @@ WorkingDirectory=$INSTALL_DIR/publish/AppHost
 Environment=ASPNETCORE_ENVIRONMENT=Production
 Environment=DANCECOURSE_RASPBERRY_PI=true
 Environment=DOTNET_DASHBOARD_URLS=http://0.0.0.0:15000
+Environment=DOTNET_URLS=http://0.0.0.0:15000
+Environment=ASPNETCORE_HTTP_PORTS=
 Environment=DOTNET_ROOT=$HOME/.dotnet
 ExecStart=$INSTALL_DIR/publish/AppHost/DanceCourseCreator.AppHost
 Restart=always

--- a/src/DanceCourseCreator.AppHost/AppHost.cs
+++ b/src/DanceCourseCreator.AppHost/AppHost.cs
@@ -11,15 +11,32 @@ builder.Services.Configure<LoggerFilterOptions>(options =>
     options.Rules.Add(new LoggerFilterRule(null, "Microsoft.AspNetCore.DataProtection", LogLevel.Error, null));
 });
 
+// Check if running on Raspberry Pi
+var isRaspberryPi = Environment.GetEnvironmentVariable("DANCECOURSE_RASPBERRY_PI") == "true";
+
+// Configure API with proper network binding for Raspberry Pi
 var api = builder.AddProject<Projects.DanceCourseCreator_API>("api")
     .WithHttpHealthCheck("/health")
     .WithExternalHttpEndpoints();
 
-builder.AddProject<Projects.DanceCourseCreator_Web>("web")
+if (isRaspberryPi)
+{
+    // Force API to bind to all interfaces on Raspberry Pi
+    api.WithEnvironment("ASPNETCORE_URLS", "http://0.0.0.0:7177");
+}
+
+// Configure Web with proper network binding for Raspberry Pi
+var web = builder.AddProject<Projects.DanceCourseCreator_Web>("web")
     .WithHttpHealthCheck("/health")
     .WithExternalHttpEndpoints()
     .WaitFor(api)
     .WithReference(api);
+
+if (isRaspberryPi)
+{
+    // Force Web to bind to all interfaces on Raspberry Pi
+    web.WithEnvironment("ASPNETCORE_URLS", "http://0.0.0.0:5001");
+}
 
 // Add a hosted service to print message after startup
 builder.Services.AddHostedService<StartupMessageService>();


### PR DESCRIPTION
…ten on all interfaces and update environment variables for proper deployment.

This pull request addresses a networking issue on Raspberry Pi deployments where the application was only accessible via `localhost` (`127.0.0.1`). The changes ensure that all relevant services bind to `0.0.0.0`, making them reachable from any device on the local network. The solution involves code-level changes, environment variable updates, and modifications to deployment scripts and service templates.

**Raspberry Pi-specific network binding fixes:**

* Updated `AppHost.cs` to detect Raspberry Pi deployments and force both API and Web projects to bind to `0.0.0.0` using the `ASPNETCORE_URLS` environment variable.
* Added a detailed documentation file `RASPBERRY_PI_NETWORK_FIX.md` explaining the problem, root cause, solution, verification steps, and security notes.

**Deployment and environment configuration:**

* Modified `raspberry-pi-start.sh` to set `DANCECOURSE_RASPBERRY_PI`, clear `ASPNETCORE_HTTP_PORTS`, and set `DOTNET_URLS` for proper network binding.
* Updated SystemD service templates in both `raspberry-pi-install.sh` and `raspberry-pi-update.sh` to include the necessary environment variables for network binding (`DOTNET_URLS`, `ASPNETCORE_HTTP_PORTS`). [[1]](diffhunk://#diff-3fbc60c13c52aa43c83f255df51585369ccb6287e460bfdbb10d4031a2046f12R1069-R1070) [[2]](diffhunk://#diff-0cbd52329bef74cc5f5a0ac91c2e8c7223cdef95f77c1dc2b998bab3c1dcdf05R364-R365)